### PR TITLE
Fixed bug with table row preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqltools-singlestore-driver",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sqltools-singlestore-driver",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@sqltools/base-driver": "^0.1.11",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SQLTools SingleStoreDB Driver",
   "description": "SQLTools Driver for SingleStoreDB",
   "icon": "icons/logo.png",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "engines": {
     "vscode": "^1.42.0"
   },

--- a/src/ls/queries.ts
+++ b/src/ls/queries.ts
@@ -4,7 +4,7 @@ import { IBaseQueries, ContextValue, NSDatabase } from '@sqltools/types';
 function escapeTableName(table: Partial<NSDatabase.ITable> | string) {
   let items: string[] = [];
   let tableObj = typeof table === 'string' ? <NSDatabase.ITable>{ label: table } : table;
-  //tableObj.schema && items.push(`\`${tableObj.schema}\``);
+  tableObj.schema && items.push(`\`${tableObj.schema.replace('`', '``')}\``);
   items.push(`\`${tableObj.label.replace('`', '``')}\``);
   return items.join('.');
 }


### PR DESCRIPTION
If the connection database option was set to an empty string, table rows were not shown. 
Added database name to table queries.