### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AdalbertMemSQL @singlestore-labs/connectors


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a repository metadata file only; no runtime code or behavior changes.
> 
> **Overview**
> Introduces a `CODEOWNERS` file that assigns default ownership of all paths (`*`) to `@AdalbertMemSQL` and `@singlestore-labs/connectors`, enabling automatic reviewer/approval routing for future changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614f70579804b90b531305a6bd8cbb3862df2ccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->